### PR TITLE
Use cache interface instead of freecache

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -74,7 +75,7 @@ func (m *CacheMiddleware) Handler(next echo.HandlerFunc) echo.HandlerFunc {
 			return nil
 		}
 
-		if err != m.cfg.GetNotFoundErr() {
+		if !errors.Is(err, m.cfg.GetNotFoundErr()) {
 			c.Logger().Errorf("error reading cache: %s", err)
 		}
 

--- a/cache_test.go
+++ b/cache_test.go
@@ -153,19 +153,11 @@ func getCachedServer(t *testing.T, cfg *Config) *httptest.Server {
 	return getCachedServerWithCode(t, cfg, http.StatusOK)
 }
 
-type frecacheWrapper struct {
-	*freecache.Cache
-}
-
-func (f frecacheWrapper) GetNotFoundErr() error {
-	return freecache.ErrNotFound
-}
-
 func getCachedServerWithCode(t *testing.T, cfg *Config, status int) *httptest.Server {
 	e := echo.New()
 
 	var i int
-	h := New(cfg, frecacheWrapper{freecache.NewCache(42 * 1024 * 1024)})(func(c echo.Context) error {
+	h := New(cfg, freecache.NewCache(42*1024*1024))(func(c echo.Context) error {
 		i++
 		return c.String(status, fmt.Sprintf("test_%d", i))
 	})

--- a/cache_test.go
+++ b/cache_test.go
@@ -153,11 +153,19 @@ func getCachedServer(t *testing.T, cfg *Config) *httptest.Server {
 	return getCachedServerWithCode(t, cfg, http.StatusOK)
 }
 
+type frecacheWrapper struct {
+	*freecache.Cache
+}
+
+func (f frecacheWrapper) GetNotFoundErr() error {
+	return freecache.ErrNotFound
+}
+
 func getCachedServerWithCode(t *testing.T, cfg *Config, status int) *httptest.Server {
 	e := echo.New()
 
 	var i int
-	h := New(cfg, freecache.NewCache(42*1024*1024))(func(c echo.Context) error {
+	h := New(cfg, frecacheWrapper{freecache.NewCache(42 * 1024 * 1024)})(func(c echo.Context) error {
 		i++
 		return c.String(status, fmt.Sprintf("test_%d", i))
 	})


### PR DESCRIPTION
This feature enables the user to implement any cache by wrapping it's methods to implement the Cache interface method.